### PR TITLE
July 2019 and Refactor schedule out of FAQ + use JSON data

### DIFF
--- a/docs-src/data.json
+++ b/docs-src/data.json
@@ -2,15 +2,22 @@
   "nextEvent": {
     "dayOfTheWeek": "Tuesday",
     "date": "July 9th",
-    "time": "5-9PM",
-    "address": "TBA",
-    "addressUrlSafe": "tba",
+    "time": "6-9PM",
+    "address": "Galvanize – New York",
+    "addressUrlSafe": "https://www.google.com/maps/place/Galvanize+-+New+York/@40.7259948,-74.0082949,15z/data=!4m2!3m1!1s0x0:0x3af58266e45afbae?sa=X&ved=2ahUKEwjFqe3LjaPiAhXxlOAKHTCAA5AQ_BIwDnoECA0QCA",
     "mentorsUrl": "https://github.com/nodeschool/nyc/issues/40",
     "ticketsUrl": "https://www.meetup.com/nodeschoolnyc/events/261514837"
   },
   "focusedSession": {
-    "title": "To Be Selected📝",
+    "title": "To Be Selected 📝",
     "speaker": "You?",
     "description": "We're currently looking for Focuses Session presenters! If you're interested in presenting a Focused Session, please feel free to create an issue to propose one!"
+  },
+  "schedule": {
+    "start": "6:00pm – Doors open && pizza 🍕.",
+    "pizza": "6:00pm - 6:30pm: Networking.",
+    "intro": "6:30pm – Introduction and opening announcements.",
+    "work": "6:45pm to 9:00pm – Workshoppers, learning, and mentorship.",
+    "end": "9:00pm – Event ends."
   }
 }

--- a/docs-src/index.mustache
+++ b/docs-src/index.mustache
@@ -84,6 +84,23 @@
       </section>
       {{/focusedSession}}
 
+      <section id="what-happens" class="what-happens  section">
+        <div class="section__content">
+          <h2>What actually happens at a NodeSchool NYC event?</h2>
+          {{ #schedule }}
+            <p>NodeSchool NYC events are an opportunity to hang out with other learners and mentors in a low stress, encouraging environment. Get set up to work on lessons with real industry tools on your own computer, at your own pace. A typical event follows this schedule:</p>
+            <ul class="schedule">
+              <li>{{ schedule.start }}</li>
+              <li>{{ schedule.intro }}</li>
+              <li>{{ schedule.work }}</li>
+              <li>{{ schedule.pizza }}</li>
+              <li>{{ schedule.end }}</li>
+            </ul>
+            <strong>Please note: Latecomers are entirely welcome!</strong>
+          {{ /schedule }}
+        </div>
+      </section>
+
       <section id="faq" class="faq section">
         <div class="faq__content section__content">
           <h2 class="faq__heading">Frequently Asked Questions</h2>
@@ -100,21 +117,6 @@
             </dt>
             <dd class="faq__answer">
               Franziska Hinkelmann (<a href="https://twitter.com/fhinkel">@fhinkel</a>), Joe Sepi (<a href="https://twitter.com/joe_sepi">@joe_sepi</a>), Tierney Cyren (<a href="https://twitter.com/bitandbang">@bitandbang</a>), and John Elliott (<a href="https://twitter.com/johnelliottdc">@johnelliottdc</a>) run the NYC chapter.
-            </dd>
-
-            <dt class="faq__question">
-              <h4 class="faq__subheading">What actually happens at a NodeSchool NYC event?</h4>
-            </dt>
-            <dd class="faq__answer">
-              NodeSchool NYC events are an opportunity to hang out with other learners and mentors in a low stress, encouraging environment. Get set up to work on lessons with real industry tools on your own computer, at your own pace. A typical event follows this schedule:
-              <ul class="schedule">
-                <li class="schedule__item"><strong>5:00</strong> - Doors open</li>
-                <li class="schedule__item"><strong>5:15</strong> - Introduction and opening announcements</li>
-                <li class="schedule__item"><strong>5:45-9:00</strong> - Learning/mentoring</li>
-                <li class="schedule__item"><strong>6:00ish</strong> - Pizza! <img src="./images/pizza-emoji.png" class="emoji" alt="pizza emoji"></li>
-                <li class="schedule__item"><strong>8:00</strong> - Event ends</li>
-              </ul>
-              <strong>Please note: Latecomers are entirely welcome!</strong>
             </dd>
 
             <dt class="faq__question">
@@ -187,7 +189,6 @@
 
       <footer id="attribution" class="attribution section">
           <p>Website gratefully forked from <a href="https://nodeschool.io/sanfrancisco/">stellar folks at NodeSchool San Francisco</a>, who forked it from the <a href="https://nodeschool.io/oakland/">fine folks at NodeSchool Oakland</a>.</p>
-          <p>Emoji icons provided free by <a href="https://www.emojione.com/">EmojiOne</a>.</p>
           <p>Fonts hosted by <a href="https://fonts.google.com/selection?selection.family=Montserrat|Raleway">Google Fonts</a>.</p>
       </footer>
     </div>

--- a/docs-src/styles/index.styl
+++ b/docs-src/styles/index.styl
@@ -260,7 +260,7 @@ $logo-width = 140px;
   display: block;
 }
 
-.faq {
+.faq, .focused {
   position: relative;
 
   &:after {
@@ -284,7 +284,7 @@ $logo-width = 140px;
   margin: 0;
 }
 
-.code-of-conduct {
+.code-of-conduct, .what-happens {
   background: $color-off-white;
   position: relative;
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,13 +42,13 @@
 
           <div class="next-event">
             <div class="next-event__description">
-              <h2 class="next-event__heading">Our Next Event is on May 7th</h2>
+              <h2 class="next-event__heading">Our Next Event is on July 9th</h2>
               <ul class="next-event__info">
                 <li class="next-event__info__item">
-                  <strong class="strong--alt">When?</strong> Tuesday, May 7th from 5-8PM (latecomers welcome!)
+                  <strong class="strong--alt">When?</strong> Tuesday, July 9th from 6-9PM (latecomers welcome!)
                 </li>
                 <li class="next-event__info__item">
-                  <strong class="strong--alt">Where?</strong> IBM Astor Place Cafe, 5th floor: 51 Astor Pl, New York, NY 10003 [<a href="http://maps.google.com/?q=51-Astor-Pl-New-York-NY-10003">map</a>]
+                  <strong class="strong--alt">Where?</strong> Galvanize – New York [<a href="http://maps.google.com/?q=https:&#x2F;&#x2F;www.google.com&#x2F;maps&#x2F;place&#x2F;Galvanize+-+New+York&#x2F;@40.7259948,-74.0082949,15z&#x2F;data&#x3D;!4m2!3m1!1s0x0:0x3af58266e45afbae?sa&#x3D;X&amp;ved&#x3D;2ahUKEwjFqe3LjaPiAhXxlOAKHTCAA5AQ_BIwDnoECA0QCA">map</a>]
                 </li>
                 <li class="next-event__info__item">
                   <strong class="strong--alt">What?</strong> Learning, mentoring, JS bffs, and pizza <img src="./images/pizza-emoji.png" class="emoji" alt="pizza emoji">
@@ -56,9 +56,9 @@
               </ul>
             </div>
             <nav class="next-event__links">
-              <a class="next-event__links__learner next-event__links__link button" href="https:&#x2F;&#x2F;www.meetup.com&#x2F;nodeschoolnyc&#x2F;events&#x2F;260005249&#x2F;">
+              <a class="next-event__links__learner next-event__links__link button" href="https:&#x2F;&#x2F;www.meetup.com&#x2F;nodeschoolnyc&#x2F;events&#x2F;261514837">
                 Sign up as a Learner
-              </a><a class="next-event__links__mentor next-event__links__link button" href="https:&#x2F;&#x2F;github.com&#x2F;nodeschool&#x2F;nyc&#x2F;issues&#x2F;34">
+              </a><a class="next-event__links__mentor next-event__links__link button" href="https:&#x2F;&#x2F;github.com&#x2F;nodeschool&#x2F;nyc&#x2F;issues&#x2F;40">
                 Sign up as a Mentor
               </a>
             </nav>
@@ -69,9 +69,24 @@
       <section id="focused-session" class="focused section">
         <div class="focused__content section__content">
           <h2 class="focused__heading">Upcoming Focused Session</h2>
-          <h3 class="focused__subheading">To Be Selected📝, by You?</h3>
+          <h3 class="focused__subheading">To Be Selected 📝, by You?</h3>
           <p>We&#39;re currently looking for Focuses Session presenters! If you&#39;re interested in presenting a Focused Session, please feel free to create an issue to propose one!</p>
           <p><em>* Please consider that capacity is limited and seats will be assigned on a first-come, first-served basis.</em></p>
+        </div>
+      </section>
+
+      <section id="what-happens" class="what-happens  section">
+        <div class="section__content">
+          <h2>What actually happens at a NodeSchool NYC event?</h2>
+            <p>NodeSchool NYC events are an opportunity to hang out with other learners and mentors in a low stress, encouraging environment. Get set up to work on lessons with real industry tools on your own computer, at your own pace. A typical event follows this schedule:</p>
+            <ul class="schedule">
+              <li>6:00pm – Doors open.</li>
+              <li>6:15pm – Introduction and opening announcements.</li>
+              <li>6:45pm to 9:00pm – Workshoppers, learning, and mentorship.</li>
+              <li>When it arrives – Pizza! 🍕</li>
+              <li>9:00pm – Event ends.</li>
+            </ul>
+            <strong>Please note: Latecomers are entirely welcome!</strong>
         </div>
       </section>
 
@@ -91,21 +106,6 @@
             </dt>
             <dd class="faq__answer">
               Franziska Hinkelmann (<a href="https://twitter.com/fhinkel">@fhinkel</a>), Joe Sepi (<a href="https://twitter.com/joe_sepi">@joe_sepi</a>), Tierney Cyren (<a href="https://twitter.com/bitandbang">@bitandbang</a>), and John Elliott (<a href="https://twitter.com/johnelliottdc">@johnelliottdc</a>) run the NYC chapter.
-            </dd>
-
-            <dt class="faq__question">
-              <h4 class="faq__subheading">What actually happens at a NodeSchool NYC event?</h4>
-            </dt>
-            <dd class="faq__answer">
-              NodeSchool NYC events are an opportunity to hang out with other learners and mentors in a low stress, encouraging environment. Get set up to work on lessons with real industry tools on your own computer, at your own pace. A typical event follows this schedule:
-              <ul class="schedule">
-                <li class="schedule__item"><strong>5:00</strong> - Doors open</li>
-                <li class="schedule__item"><strong>5:15</strong> - Introduction and opening announcements</li>
-                <li class="schedule__item"><strong>5:45-9:00</strong> - Learning/mentoring</li>
-                <li class="schedule__item"><strong>6:00ish</strong> - Pizza! <img src="./images/pizza-emoji.png" class="emoji" alt="pizza emoji"></li>
-                <li class="schedule__item"><strong>8:00</strong> - Event ends</li>
-              </ul>
-              <strong>Please note: Latecomers are entirely welcome!</strong>
             </dd>
 
             <dt class="faq__question">
@@ -132,7 +132,7 @@
                 <ul><li>Having also completed some elective workshoppers is a great bonus.</li></ul>
                 <li>Review the <a href="https://github.com/nodeschool/organizers/wiki/Event-Mentor-Best-Practices">Mentor Best Practices</a> wiki page.</li>
                 <li>Arrive 30 minutes early (4:30p) so we can get setup and have our mentor meeting.</li>
-                <li>Sign up on <a href="https:&#x2F;&#x2F;github.com&#x2F;nodeschool&#x2F;nyc&#x2F;issues&#x2F;34">the event's GitHub issue</a>!</li>
+                <li>Sign up on <a href="https:&#x2F;&#x2F;github.com&#x2F;nodeschool&#x2F;nyc&#x2F;issues&#x2F;40">the event's GitHub issue</a>!</li>
               </ul>
             </dd>
 
@@ -154,7 +154,7 @@
           event participants in any form. Sexual language and imagery is not appropriate for
           any event venue, including talks, workshops, parties, Twitter and other online media.
           Event participants violating these rules may be sanctioned or expelled from the event
-          at the discretion of the event organisers.</p>
+          at the discretion of the event organizers.</p>
 
           <h3><strong>NodeSchool NYC</strong></h3>
 

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -648,10 +648,12 @@ footer ul {
 .focused {
   display: block;
 }
-.faq {
+.faq,
+.focused {
   position: relative;
 }
-.faq:after {
+.faq:after,
+.focused:after {
   content: '';
   display: block;
   position: absolute;
@@ -668,11 +670,13 @@ footer ul {
 .faq__answer {
   margin: 0;
 }
-.code-of-conduct {
+.code-of-conduct,
+.what-happens {
   background: #f7f7f7;
   position: relative;
 }
-.code-of-conduct:after {
+.code-of-conduct:after,
+.what-happens:after {
   content: '';
   display: block;
   position: absolute;


### PR DESCRIPTION
This PR adds July 2019 to the public website and also refactors the schedule to be a bit... nicer, both visually and as maintainers. 

Visually, it moves the schedule section up out of FAQ and into its own section.

It also moves the schedule data to `data.json`, so we can tweak as necessary – which seems to be needed on an event-by-event basis.

Before:
![image](https://user-images.githubusercontent.com/502396/57952967-b9eccf00-78bc-11e9-9dbe-70f635da845e.png)

After:
![image](https://user-images.githubusercontent.com/502396/57952975-c2450a00-78bc-11e9-815c-8b2512cbd469.png)
