### PR TITLE
Remove unnecessary npm scripts and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,6 @@
     "docs:build:html": "mustache docs-src/data.json docs-src/index.mustache > docs/index.html",
     "docs:build:styles": "mkdirp docs/styles && stylus docs-src/styles/index.styl --out docs/styles --include node_modules --include-css",
     "docs:build:images": "ncp docs-src/images docs/images",
-    "docs:watch": "mkdirp docs && npm-run-all --parallel docs:watch:*",
-    "docs:watch:html": "chokidar docs-src/index.mustache -c 'npm run docs:build:html' --initial",
-    "docs:watch:styles": "npm run docs:build:styles -- -w",
-    "docs:watch:images": "chokidar docs-src/images/* -c 'npm run docs:build:images' --initial",
-    "docs:watch:fonts": "chokidar docs-src/fonts/* -c 'npm run docs:build:fonts' --initial",
-    "docs:server": "static docs --port=${PORT:=8080} --host-address=${HOST:=127.0.0.1}",
-    "docs:dev": "npm-run-all --parallel docs:watch docs:server"
   },
   "repository": {
     "type": "git",
@@ -31,11 +24,9 @@
     "mustache": "^2.2.1"
   },
   "devDependencies": {
-    "chokidar-cli": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mustache": "^2.3.0",
     "ncp": "^2.0.0",
-    "node-static": "^0.7.9",
     "npm-run-all": "^4.0.2",
     "stylus": "^0.54.5"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs:build": "mkdirp docs && npm-run-all --serial docs:build:*",
     "docs:build:html": "mustache docs-src/data.json docs-src/index.mustache > docs/index.html",
     "docs:build:styles": "mkdirp docs/styles && stylus docs-src/styles/index.styl --out docs/styles --include node_modules --include-css",
-    "docs:build:images": "ncp docs-src/images docs/images",
+    "docs:build:images": "ncp docs-src/images docs/images"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This removes the watch scripts, in addition to a couple devDeps that are currently triggering both GitHub security warnings and audit warnings on local npm install.