### PR TITLE
switch time from 4:30 to 5:30

### DIFF
--- a/docs-src/index.mustache
+++ b/docs-src/index.mustache
@@ -142,7 +142,7 @@
                 <li>Have already completed the <a href="http://nodeschool.io/#workshopper-list">core NodeSchool workshoppers</a> before the event.</li>
                 <ul><li>Having also completed some elective workshoppers is a great bonus.</li></ul>
                 <li>Review the <a href="https://github.com/nodeschool/organizers/wiki/Event-Mentor-Best-Practices">Mentor Best Practices</a> wiki page.</li>
-                <li>Arrive 30 minutes early (4:30p) so we can get setup and have our mentor meeting.</li>
+                <li>Arrive 30 minutes early (5:30p) so we can get setup and have our mentor meeting.</li>
                 <li>Sign up on <a href="{{nextEvent.mentorsUrl}}">the event's GitHub issue</a>!</li>
               </ul>
             </dd>

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,7 +131,7 @@
                 <li>Have already completed the <a href="http://nodeschool.io/#workshopper-list">core NodeSchool workshoppers</a> before the event.</li>
                 <ul><li>Having also completed some elective workshoppers is a great bonus.</li></ul>
                 <li>Review the <a href="https://github.com/nodeschool/organizers/wiki/Event-Mentor-Best-Practices">Mentor Best Practices</a> wiki page.</li>
-                <li>Arrive 30 minutes early (4:30p) so we can get setup and have our mentor meeting.</li>
+                <li>Arrive 30 minutes early (5:30p) so we can get setup and have our mentor meeting.</li>
                 <li>Sign up on <a href="https:&#x2F;&#x2F;github.com&#x2F;nodeschool&#x2F;nyc&#x2F;issues&#x2F;47">the event's GitHub issue</a>!</li>
               </ul>
             </dd>


### PR DESCRIPTION
I noticed the site says mentors should arrive 30 mins. early but it looks like the time was off and listed as 4:30 instead of 5:30.

I updated based on this issue listing the time as 5:30 https://github.com/nodeschool/nyc/issues/47#issue-470030684 and the events start time being 6:00pm.