### PR TITLE
Update README/package.json with suggestions from @M0nica

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ The website is generated using Mustache templates, Stylus, and JavaScript. It ru
 For a development server, run
 
 ```bash
-$ npm run docs:dev
+$ npm run docs:build
 ```
 
 Now you can visit `http://localhost:8080/` in your browser to see the website.
 
-**Important**: edit files inside the directory `docs-src`. Files are compiled into the `docs` folder. Changes will be compiled automatically by the `npm run docs:dev` command.
+**Important**: edit files inside the directory `docs-src`. Files are compiled into the `docs` folder.
 
 ## Special thanks
 

--- a/package.json
+++ b/package.json
@@ -6,23 +6,20 @@
     "doc": "docs"
   },
   "scripts": {
-    "docs:build": "mkdirp docs && npm-run-all --serial docs:build:*",
-    "docs:build:html": "mustache docs-src/data.json docs-src/index.mustache > docs/index.html",
-    "docs:build:styles": "mkdirp docs/styles && stylus docs-src/styles/index.styl --out docs/styles --include node_modules --include-css",
-    "docs:build:images": "ncp docs-src/images docs/images"
+    "build": "mkdirp docs && npm-run-all --serial build:*",
+    "build:html": "mustache docs-src/data.json docs-src/index.mustache > docs/index.html",
+    "build:styles": "mkdirp docs/styles && stylus docs-src/styles/index.styl --out docs/styles --include node_modules --include-css",
+    "build:images": "ncp docs-src/images docs/images"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nodeschool/sanfrancisco.git"
+    "url": "https://github.com/nodeschool/nyc.git"
   },
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/nodeschool/nyc/issues"
   },
   "homepage": "https://nodeschool.io/nyc",
-  "dependencies": {
-    "mustache": "^2.2.1"
-  },
   "devDependencies": {
     "mkdirp": "^0.5.1",
     "mustache": "^2.3.0",


### PR DESCRIPTION
Fixes #52; also removes the `docs:` prefix that was on every script. It doesn't seem important to have it everywhere. I am happy to reverse that if somebody is attached to the prefix :)

Thanks @M0nica 👍 